### PR TITLE
fix(setup): create env script must be called from .kit

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -25,7 +25,7 @@ console.log(`Set KIT and KENV to ${kitPath()} and ${kenvPath()}`)
 let envExists = await isFile(kenvPath(".env"))
 if (!envExists) {
   console.log(`\n\n---- Creating ${kenvPath(".env")} ----`)
-  await kit(kenvPath("setup", "create-env.js"))
+  await kit(kitPath("setup", "create-env.js"));
 }
 
 console.log(`Link ${kitPath()} to ${kenvPath()}`)


### PR DESCRIPTION
After struggling a while to run the install-kit script, I've noticed the "create-env" setup script is being called from the wrong folder. The code is referencing .kenv when it should reference .kit.